### PR TITLE
load ag-table script only where needed

### DIFF
--- a/BlazorAgGridTest/Pages/FetchData.razor
+++ b/BlazorAgGridTest/Pages/FetchData.razor
@@ -5,6 +5,7 @@
 @using BlazorAgGridTest.Data
 @using Newtonsoft.Json
 @inject WeatherForecastService ForecastService
+@inject IJSRuntime JS
 
 @if (Peoples == null)
 {
@@ -52,6 +53,11 @@ else
     {
         var json = File.ReadAllText("Data/PeopleData.txt");
         Peoples = JsonConvert.DeserializeObject<List<PeopleModel>>(json);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await JS.InvokeVoidAsync("loadJs", "./js/JavaScript.js");
     }
 
     protected void OnEdit(PeopleModel peopleModel)

--- a/BlazorAgGridTest/Pages/NoPages.razor
+++ b/BlazorAgGridTest/Pages/NoPages.razor
@@ -4,6 +4,7 @@
 
 @using BlazorAgGridTest.Data
 @using Newtonsoft.Json
+@inject IJSRuntime JS
 
 <h1>Grid (@Peoples?.Count)</h1>
 
@@ -37,6 +38,11 @@ else
     {
         var json = File.ReadAllText("Data/PeopleData.txt");
         Peoples = JsonConvert.DeserializeObject<List<PeopleModel>>(json);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await JS.InvokeVoidAsync("loadJs", "./js/JavaScript.js");
     }
 
 }

--- a/BlazorAgGridTest/Pages/_Layout.cshtml
+++ b/BlazorAgGridTest/Pages/_Layout.cshtml
@@ -13,7 +13,7 @@
     <link href="BlazorAgGridTest.styles.css" rel="stylesheet" />
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 
-    <script src="js/JavaScript.js"></script>
+    <script src="js/site.js"></script>
 
     <!-- Ag Grid -->
     <!-- Include the JS for AG Grid -->

--- a/BlazorAgGridTest/wwwroot/js/site.js
+++ b/BlazorAgGridTest/wwwroot/js/site.js
@@ -1,0 +1,20 @@
+function loadJs(sourceUrl) {
+    if (sourceUrl.Length == 0) {
+        console.error("Invalid source URL");
+        return;
+    }
+
+    var tag = document.createElement('script');
+    tag.src = sourceUrl;
+    tag.type = "text/javascript";
+
+    tag.onload = function() {
+        console.log("Script loaded successfully");
+    }
+
+    tag.onerror = function() {
+        console.error("Failed to load script");
+    }
+
+    document.body.appendChild(tag);
+}


### PR DESCRIPTION
das laden der js-scripte wird über ein eigenes script (site.js) behandelt und nur dort aufgerufen, wo es auch benötigt wird.
Zusätzlich kann man in Zukunft auch pro Seite ein eigenes AG-Table-Script einbinden.